### PR TITLE
Sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ GRANT CONNECT ON DATABASE shard_0 TO pgdog;
 GRANT CONNECT ON DATABASE shard_1 TO pgdog;
 ```
 
+Once the databases are created, you can launch pgDog with the sharded configuration:
+
+```bash
+cargo run -- --config pgdog-sharded.toml --users users-sharded.toml
+```
+
 ### Configuration
 
 pgDog is highly configurable and many aspects of its operation can be tweaked at runtime, without having

--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ Examples of plugins can be found in [examples](https://github.com/levkk/pgdog/tr
 
 &#128216; **[Plugins](https://pgdog.dev/features/plugins/)**
 
+### Sharding
+
+_This feature is a work in progress._
+
+pgDog is able to handle deployments with multiple shards by routing queries automatically to one or more shards. The `pgdog-routing` plugin parses
+queries, extracts tables and columns, and figures out which shard(s) the query should go to based on the parameters. Not all operations are supported, but
+a lot of common use cases are covered.
+
+&#128216; **[Sharding](https://pgdog.dev/features/sharding/)**
+
+#### Local testing
+
+The configuration files for a sharded database are provided in the repository. To make it work locally, setup the required databases like so:
+
+```postgresql
+CREATE DATABASE shard_0;
+CREATE DATABASE shard_1;
+
+GRANT CONNECT ON DATABASE shard_0 TO pgdog;
+GRANT CONNECT ON DATABASE shard_1 TO pgdog;
+```
+
 ### Configuration
 
 pgDog is highly configurable and many aspects of its operation can be tweaked at runtime, without having

--- a/pgdog-plugin/include/types.h
+++ b/pgdog-plugin/include/types.h
@@ -63,7 +63,8 @@ typedef enum OrderByDirection {
  * Column sorting.
 */
 typedef struct OrderBy {
-    int column;
+    char *column_name;
+    int column_index;
     OrderByDirection direction;
 } OrderBy;
 

--- a/pgdog-plugin/include/types.h
+++ b/pgdog-plugin/include/types.h
@@ -16,7 +16,7 @@ typedef struct Parameter {
 typedef struct Query {
     /* Length of the query */
     int len;
-  
+
     /* The query text. */
     const char *query;
 
@@ -51,6 +51,22 @@ typedef enum Shard {
     ALL = -2,
 } Shard;
 
+/*
+ * Column sort direction.
+*/
+typedef enum OrderByDirection {
+    ASCENDING,
+    DESCENDING,
+} OrderByDirection;
+
+/*
+ * Column sorting.
+*/
+typedef struct OrderBy {
+    int column;
+    OrderByDirection direction;
+} OrderBy;
+
 /**
  * Route the query should take.
  *
@@ -58,6 +74,8 @@ typedef enum Shard {
 typedef struct Route {
     Affinity affinity;
     int shard;
+    int num_order_by;
+    OrderBy *order_by;
 } Route;
 
 /*

--- a/pgdog-plugin/src/bindings.rs
+++ b/pgdog-plugin/src/bindings.rs
@@ -51,15 +51,19 @@ pub type OrderByDirection = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrderBy {
-    pub column: ::std::os::raw::c_int,
+    pub column_name: *mut ::std::os::raw::c_char,
+    pub column_index: ::std::os::raw::c_int,
     pub direction: OrderByDirection,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of OrderBy"][::std::mem::size_of::<OrderBy>() - 8usize];
-    ["Alignment of OrderBy"][::std::mem::align_of::<OrderBy>() - 4usize];
-    ["Offset of field: OrderBy::column"][::std::mem::offset_of!(OrderBy, column) - 0usize];
-    ["Offset of field: OrderBy::direction"][::std::mem::offset_of!(OrderBy, direction) - 4usize];
+    ["Size of OrderBy"][::std::mem::size_of::<OrderBy>() - 16usize];
+    ["Alignment of OrderBy"][::std::mem::align_of::<OrderBy>() - 8usize];
+    ["Offset of field: OrderBy::column_name"]
+        [::std::mem::offset_of!(OrderBy, column_name) - 0usize];
+    ["Offset of field: OrderBy::column_index"]
+        [::std::mem::offset_of!(OrderBy, column_index) - 8usize];
+    ["Offset of field: OrderBy::direction"][::std::mem::offset_of!(OrderBy, direction) - 12usize];
 };
 #[doc = " Route the query should take."]
 #[repr(C)]

--- a/pgdog-plugin/src/bindings.rs
+++ b/pgdog-plugin/src/bindings.rs
@@ -45,19 +45,39 @@ pub const Shard_ANY: Shard = -1;
 pub const Shard_ALL: Shard = -2;
 #[doc = " In case the plugin doesn't know which shard to route the\n the query, it can decide to route it to any shard or to all\n shards. All shard queries return a result assembled by pgDog."]
 pub type Shard = ::std::os::raw::c_int;
+pub const OrderByDirection_ASCENDING: OrderByDirection = 0;
+pub const OrderByDirection_DESCENDING: OrderByDirection = 1;
+pub type OrderByDirection = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrderBy {
+    pub column: ::std::os::raw::c_int,
+    pub direction: OrderByDirection,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of OrderBy"][::std::mem::size_of::<OrderBy>() - 8usize];
+    ["Alignment of OrderBy"][::std::mem::align_of::<OrderBy>() - 4usize];
+    ["Offset of field: OrderBy::column"][::std::mem::offset_of!(OrderBy, column) - 0usize];
+    ["Offset of field: OrderBy::direction"][::std::mem::offset_of!(OrderBy, direction) - 4usize];
+};
 #[doc = " Route the query should take."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Route {
     pub affinity: Affinity,
     pub shard: ::std::os::raw::c_int,
+    pub num_order_by: ::std::os::raw::c_int,
+    pub order_by: *mut OrderBy,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Route"][::std::mem::size_of::<Route>() - 8usize];
-    ["Alignment of Route"][::std::mem::align_of::<Route>() - 4usize];
+    ["Size of Route"][::std::mem::size_of::<Route>() - 24usize];
+    ["Alignment of Route"][::std::mem::align_of::<Route>() - 8usize];
     ["Offset of field: Route::affinity"][::std::mem::offset_of!(Route, affinity) - 0usize];
     ["Offset of field: Route::shard"][::std::mem::offset_of!(Route, shard) - 4usize];
+    ["Offset of field: Route::num_order_by"][::std::mem::offset_of!(Route, num_order_by) - 8usize];
+    ["Offset of field: Route::order_by"][::std::mem::offset_of!(Route, order_by) - 16usize];
 };
 pub const RoutingDecision_FORWARD: RoutingDecision = 1;
 pub const RoutingDecision_REWRITE: RoutingDecision = 2;

--- a/pgdog-plugin/src/lib.rs
+++ b/pgdog-plugin/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bindings;
 pub mod c_api;
 pub mod config;
 pub mod input;
+pub mod order_by;
 pub mod output;
 pub mod parameter;
 pub mod plugin;

--- a/pgdog-plugin/src/order_by.rs
+++ b/pgdog-plugin/src/order_by.rs
@@ -34,7 +34,7 @@ impl OrderBy {
 
     /// Get column name if any.
     pub fn name(&self) -> Option<&str> {
-        if self.column_name.is_null() || self.column_index < 0 {
+        if self.column_name.is_null() || self.column_index >= 0 {
             None
         } else {
             unsafe { CStr::from_ptr(self.column_name).to_str().ok() }

--- a/pgdog-plugin/src/order_by.rs
+++ b/pgdog-plugin/src/order_by.rs
@@ -1,0 +1,43 @@
+use std::{
+    ffi::{CStr, CString},
+    ptr::null_mut,
+};
+
+use crate::{OrderBy, OrderByDirection};
+
+impl OrderBy {
+    pub(crate) fn drop(&self) {
+        if !self.column_name.is_null() {
+            unsafe { drop(CString::from_raw(self.column_name)) }
+        }
+    }
+
+    /// Order by column name.
+    pub fn column_name(name: &str, direction: OrderByDirection) -> Self {
+        let column_name = CString::new(name.as_bytes()).unwrap();
+
+        Self {
+            column_name: column_name.into_raw(),
+            column_index: -1,
+            direction,
+        }
+    }
+
+    /// Order by column index.
+    pub fn column_index(index: usize, direction: OrderByDirection) -> Self {
+        Self {
+            column_name: null_mut(),
+            column_index: index as i32,
+            direction,
+        }
+    }
+
+    /// Get column name if any.
+    pub fn name(&self) -> Option<&str> {
+        if self.column_name.is_null() || self.column_index < 0 {
+            None
+        } else {
+            unsafe { CStr::from_ptr(self.column_name).to_str().ok() }
+        }
+    }
+}

--- a/pgdog-plugin/src/output.rs
+++ b/pgdog-plugin/src/output.rs
@@ -13,12 +13,8 @@ impl Output {
 
     pub unsafe fn drop(&self) {
         #[allow(non_upper_case_globals)]
-        match self.decision {
-            RoutingDecision_FORWARD => {
-                self.output.route.drop();
-            }
-
-            _ => (),
+        if self.decision == RoutingDecision_FORWARD {
+            self.output.route.drop();
         }
     }
 }

--- a/pgdog-plugin/src/output.rs
+++ b/pgdog-plugin/src/output.rs
@@ -10,4 +10,15 @@ impl Output {
             output: RoutingOutput::new_route(Route::unknown()),
         }
     }
+
+    pub unsafe fn drop(&self) {
+        #[allow(non_upper_case_globals)]
+        match self.decision {
+            RoutingDecision_FORWARD => {
+                self.output.route.drop();
+            }
+
+            _ => (),
+        }
+    }
 }

--- a/pgdog-plugin/src/route.rs
+++ b/pgdog-plugin/src/route.rs
@@ -1,6 +1,11 @@
 //! Query routing helpers.
 #![allow(non_upper_case_globals)]
 
+use std::{
+    alloc::{alloc, dealloc, Layout},
+    ptr::{copy, null_mut},
+};
+
 use crate::bindings::*;
 
 impl RoutingOutput {
@@ -38,6 +43,8 @@ impl Route {
         Route {
             shard: Shard_ANY,
             affinity: Affinity_UNKNOWN,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -46,6 +53,8 @@ impl Route {
         Route {
             shard: shard as i32,
             affinity: Affinity_READ,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -54,6 +63,8 @@ impl Route {
         Route {
             shard: shard as i32,
             affinity: Affinity_WRITE,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -62,6 +73,8 @@ impl Route {
         Self {
             affinity: Affinity_READ,
             shard: Shard_ANY,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -70,6 +83,8 @@ impl Route {
         Self {
             affinity: Affinity_READ,
             shard: Shard_ALL,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -78,6 +93,8 @@ impl Route {
         Self {
             affinity: Affinity_WRITE,
             shard: Shard_ANY,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -86,6 +103,8 @@ impl Route {
         Self {
             affinity: Affinity_WRITE,
             shard: Shard_ALL,
+            num_order_by: 0,
+            order_by: null_mut(),
         }
     }
 
@@ -131,5 +150,23 @@ impl Route {
     /// The plugin has no idea where to route this query.
     pub fn is_unknown(&self) -> bool {
         self.shard == Shard_ANY && self.affinity == Affinity_UNKNOWN
+    }
+
+    /// Add order by columns to the route.
+    pub fn order_by(&mut self, order_by: &[OrderBy]) {
+        let num_order_by = order_by.len();
+        let layout = Layout::array::<OrderBy>(num_order_by).unwrap();
+        let ptr = unsafe { alloc(layout) as *mut OrderBy };
+        unsafe { copy(order_by.as_ptr(), ptr, num_order_by) };
+        self.num_order_by = num_order_by as i32;
+        self.order_by = ptr;
+    }
+
+    /// Deallocate memory.
+    pub(crate) unsafe fn drop(&self) {
+        if self.num_order_by > 0 {
+            let layout = Layout::array::<OrderBy>(self.num_order_by as usize).unwrap();
+            dealloc(self.order_by as *mut u8, layout);
+        }
     }
 }

--- a/pgdog-plugin/src/route.rs
+++ b/pgdog-plugin/src/route.rs
@@ -165,6 +165,7 @@ impl Route {
     /// Deallocate memory.
     pub(crate) unsafe fn drop(&self) {
         if self.num_order_by > 0 {
+            (0..self.num_order_by).for_each(|index| (*self.order_by.offset(index as isize)).drop());
             let layout = Layout::array::<OrderBy>(self.num_order_by as usize).unwrap();
             dealloc(self.order_by as *mut u8, layout);
         }

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -55,6 +55,11 @@ impl Binding {
                     // Loop until we read a message from a shard
                     // or there are no more messages to be read.
                     loop {
+                        // Return all sorted data rows if any.
+                        if let Some(message) = state.message() {
+                            return Ok(message);
+                        }
+
                         let pending = shards.iter_mut().filter(|s| !s.done());
                         let mut read = false;
 

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 
 mod binding;
 mod multi_shard;
+mod sort_buffer;
+
 use binding::Binding;
 use multi_shard::MultiShard;
 
@@ -112,7 +114,7 @@ impl Connection {
             }
             let num_shards = shards.len();
 
-            self.binding = Binding::MultiShard(shards, MultiShard::new(num_shards));
+            self.binding = Binding::MultiShard(shards, MultiShard::new(num_shards, route));
         }
 
         Ok(())

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -1,12 +1,12 @@
 //! Server connection requested by a frontend.
 
-use pgdog_plugin::Route;
 use tokio::time::sleep;
 
 use crate::{
     admin::backend::Backend,
     backend::databases::databases,
     config::PoolerMode,
+    frontend::router::Route,
     net::messages::{BackendKeyData, Message, ParameterStatus, Protocol},
 };
 

--- a/pgdog/src/backend/pool/connection/multi_shard.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard.rs
@@ -9,10 +9,17 @@ use crate::net::messages::{
 /// Multi-shard state.
 #[derive(Default)]
 pub(super) struct MultiShard {
+    /// Number of shards we are connected to.
     shards: usize,
+    /// How many rows we received so far.
     rows: usize,
+    /// Number of ReadyForQuery messages.
     rfq: usize,
+    /// Number of CommandComplete messages.
     cc: usize,
+    /// Number of NoData messages.
+    nd: usize,
+    /// First RowDescription we received from any shard.
     rd: Option<RowDescription>,
 }
 
@@ -65,6 +72,12 @@ impl MultiShard {
                     }
                 } else {
                     self.rd = Some(rd);
+                    forward = Some(message);
+                }
+            }
+            'I' => {
+                self.nd += 1;
+                if self.nd == self.shards {
                     forward = Some(message);
                 }
             }

--- a/pgdog/src/backend/pool/connection/multi_shard.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard.rs
@@ -60,6 +60,7 @@ impl MultiShard {
                     None
                 };
             }
+
             'C' => {
                 let cc = CommandComplete::from_bytes(message.to_bytes()?)?;
                 let has_rows = if let Some(rows) = cc.rows()? {
@@ -84,6 +85,7 @@ impl MultiShard {
                     }
                 }
             }
+
             'T' => {
                 let rd = RowDescription::from_bytes(message.to_bytes()?)?;
                 if let Some(ref prev) = self.rd {
@@ -95,6 +97,7 @@ impl MultiShard {
                     forward = Some(message);
                 }
             }
+
             'I' => {
                 self.nd += 1;
                 if self.nd == self.shards {

--- a/pgdog/src/backend/pool/connection/multi_shard.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard.rs
@@ -79,7 +79,6 @@ impl MultiShard {
 
                     if has_rows {
                         self.command_complete = Some(cc.rewrite(self.rows)?.message()?);
-                        // forward = Some(cc.rewrite(self.rows)?.message()?);
                     } else {
                         forward = Some(cc.message()?);
                     }

--- a/pgdog/src/backend/pool/connection/sort_buffer.rs
+++ b/pgdog/src/backend/pool/connection/sort_buffer.rs
@@ -95,7 +95,7 @@ impl SortBuffer {
     /// Take messages from buffer.
     pub(super) fn take(&mut self) -> Option<Message> {
         if self.full {
-            self.buffer.pop_front().map(|s| s.message().ok()).flatten()
+            self.buffer.pop_front().and_then(|s| s.message().ok())
         } else {
             None
         }

--- a/pgdog/src/backend/pool/connection/sort_buffer.rs
+++ b/pgdog/src/backend/pool/connection/sort_buffer.rs
@@ -1,0 +1,80 @@
+//! Buffer messages to sort them later.
+
+use std::{cmp::Ordering, collections::VecDeque};
+
+use crate::{
+    frontend::router::route::OrderBy,
+    net::messages::{DataRow, FromBytes, Message, Protocol, RowDescription, ToBytes},
+};
+
+#[derive(Default)]
+pub(super) struct SortBuffer {
+    buffer: VecDeque<DataRow>,
+    full: bool,
+}
+
+impl SortBuffer {
+    /// Add message to buffer.
+    pub(super) fn add(&mut self, message: Message) -> Result<(), super::Error> {
+        let dr = DataRow::from_bytes(message.to_bytes()?)?;
+
+        self.buffer.push_back(dr);
+
+        Ok(())
+    }
+
+    /// Mark the buffer as full. It will start returning messages now.
+    /// Caller is responsible for sorting the buffer if needed.
+    pub(super) fn full(&mut self) {
+        self.full = true;
+    }
+
+    /// Sort the buffer.
+    pub(super) fn sort(&mut self, columns: &[OrderBy], rd: &RowDescription) {
+        let order_by = move |a: &DataRow, b: &DataRow| -> Ordering {
+            for column in columns {
+                let index = column.index();
+                let ordering = if let Some(field) = rd.field(index) {
+                    let text = field.is_text();
+                    if field.is_int() {
+                        let a = a.get_int(index, text);
+                        let b = b.get_int(index, text);
+                        if column.asc() {
+                            a.partial_cmp(&b)
+                        } else {
+                            b.partial_cmp(&a)
+                        }
+                    } else if field.is_float() {
+                        let a = a.get_float(index, text);
+                        let b = b.get_float(index, text);
+                        if column.asc() {
+                            a.partial_cmp(&b)
+                        } else {
+                            b.partial_cmp(&a)
+                        }
+                    } else {
+                        continue;
+                    }
+                } else {
+                    continue;
+                };
+
+                if ordering != Some(Ordering::Equal) {
+                    return ordering.unwrap_or(Ordering::Equal);
+                }
+            }
+            Ordering::Equal
+        };
+
+        self.buffer.make_contiguous().sort_by(order_by);
+    }
+
+    /// Take messages from buffer.
+    pub(super) fn take(&mut self) -> Option<Message> {
+        if self.full {
+            self.buffer.pop_front().map(|s| s.message().ok()).flatten()
+        } else {
+            None
+        }
+    }
+}

--- a/pgdog/src/backend/pool/replicas.rs
+++ b/pgdog/src/backend/pool/replicas.rs
@@ -20,9 +20,13 @@ use super::{Error, Guard, Pool, PoolConfig};
 /// Replicas pools.
 #[derive(Clone)]
 pub struct Replicas {
+    /// Connection pools.
     pub(super) pools: Vec<Pool>,
+    /// Checkout timeout.
     pub(super) checkout_timeout: Duration,
+    /// Round robin atomic counter.
     pub(super) round_robin: Arc<AtomicUsize>,
+    /// Chosen load balancing strategy.
     pub(super) lb_strategy: LoadBalancingStrategy,
 }
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -13,7 +13,6 @@ use arc_swap::ArcSwap;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tracing::info;
-#[cfg(not(debug_assertions))]
 use tracing::warn;
 
 use crate::util::random_string;
@@ -54,9 +53,13 @@ impl ConfigAndUsers {
                 Ok(config) => config,
                 Err(err) => return Err(Error::config(&config, err)),
             };
-            info!("loaded pgdog.toml");
+            info!("loaded \"{}\"", config_path.display());
             config
         } else {
+            warn!(
+                "\"{}\" doesn't exist or not a valid, loading defaults instead",
+                config_path.display()
+            );
             Config::default()
         };
 
@@ -69,9 +72,13 @@ impl ConfigAndUsers {
 
         let users: Users = if let Ok(users) = read_to_string(users_path) {
             let users = toml::from_str(&users)?;
-            info!("loaded users.toml");
+            info!("loaded \"{}\"", users_path.display());
             users
         } else {
+            warn!(
+                "\"{}\" doesn't exist or is invalid, loading defaults instead",
+                users_path.display()
+            );
             Users::default()
         };
 

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -2,16 +2,18 @@
 
 use crate::{backend::Cluster, plugin::plugins};
 
-use pgdog_plugin::{Input, Route, RoutingInput};
+use pgdog_plugin::{Input, RoutingInput};
 use tokio::time::Instant;
 use tracing::debug;
 
 pub mod error;
 pub mod request;
+pub mod route;
 
 use request::Request;
 
 pub use error::Error;
+pub use route::Route;
 
 use super::Buffer;
 
@@ -75,7 +77,8 @@ impl Router {
                             continue;
                         }
 
-                        self.route = route;
+                        self.route = route.into();
+                        unsafe { output.drop() }
 
                         debug!(
                             "routing {} to shard {} [{}, {:.3}ms]",

--- a/pgdog/src/frontend/router/route.rs
+++ b/pgdog/src/frontend/router/route.rs
@@ -1,0 +1,100 @@
+//! Convert `pgdog_plugin::Route` to a route which is [`Send`].
+
+#![allow(non_upper_case_globals)]
+use pgdog_plugin::{
+    Affinity, Affinity_READ, Affinity_UNKNOWN, Affinity_WRITE, OrderByDirection_ASCENDING,
+    OrderByDirection_DESCENDING,
+};
+
+#[derive(Copy, Clone, Debug)]
+pub enum OrderBy {
+    Asc(usize),
+    Desc(usize),
+}
+
+/// Query route.
+#[derive(Clone, Debug)]
+pub struct Route {
+    shard: Option<usize>,
+    all_shards: bool,
+    affinity: Affinity,
+    order_by: Vec<OrderBy>,
+}
+
+impl Route {
+    /// Get shard if any.
+    pub fn shard(&self) -> Option<usize> {
+        self.shard
+    }
+
+    /// Should this query go to all shards?
+    pub fn is_all_shards(&self) -> bool {
+        self.all_shards
+    }
+
+    /// We don't know where the query should go.
+    pub fn unknown() -> Self {
+        Self {
+            shard: None,
+            all_shards: false,
+            affinity: Affinity_UNKNOWN,
+            order_by: vec![],
+        }
+    }
+
+    /// The query can be served by a read replica.
+    pub fn is_read(&self) -> bool {
+        self.affinity == Affinity_READ
+    }
+
+    /// The query must be served by a primary.
+    pub fn is_write(&self) -> bool {
+        self.affinity == Affinity_WRITE
+    }
+
+    /// Create new write route for the given shard.
+    pub fn write(shard: usize) -> Self {
+        Self {
+            shard: Some(shard),
+            affinity: Affinity_WRITE,
+            all_shards: false,
+            order_by: vec![],
+        }
+    }
+
+    /// Get ORDER BY columns.
+    pub fn order_by(&self) -> &[OrderBy] {
+        &self.order_by
+    }
+}
+
+impl From<pgdog_plugin::OrderBy> for OrderBy {
+    fn from(value: pgdog_plugin::OrderBy) -> Self {
+        match value.direction {
+            OrderByDirection_ASCENDING => OrderBy::Asc(value.column as usize),
+            OrderByDirection_DESCENDING => OrderBy::Desc(value.column as usize),
+            _ => unreachable!("OrderByDirection enum can only be ASCENDING or DESCENDING"),
+        }
+    }
+}
+
+impl From<pgdog_plugin::Route> for Route {
+    fn from(value: pgdog_plugin::Route) -> Self {
+        let all_shards = value.is_all_shards();
+        let shard = value.shard().map(|s| s as usize);
+        let affinity = value.affinity;
+        let mut order_by = vec![];
+
+        for i in 0..value.num_order_by {
+            let column = unsafe { value.order_by.offset(i as isize) };
+            order_by.push(unsafe { *column }.into());
+        }
+
+        Route {
+            all_shards,
+            shard,
+            affinity,
+            order_by,
+        }
+    }
+}

--- a/pgdog/src/frontend/router/route.rs
+++ b/pgdog/src/frontend/router/route.rs
@@ -12,6 +12,24 @@ pub enum OrderBy {
     Desc(usize),
 }
 
+impl OrderBy {
+    /// ORDER BY x ASC
+    pub fn asc(&self) -> bool {
+        match self {
+            OrderBy::Asc(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Column index.
+    pub fn index(&self) -> usize {
+        match self {
+            OrderBy::Asc(column) => *column,
+            OrderBy::Desc(column) => *column,
+        }
+    }
+}
+
 /// Query route.
 #[derive(Clone, Debug)]
 pub struct Route {
@@ -19,6 +37,12 @@ pub struct Route {
     all_shards: bool,
     affinity: Affinity,
     order_by: Vec<OrderBy>,
+}
+
+impl Default for Route {
+    fn default() -> Self {
+        Route::unknown()
+    }
 }
 
 impl Route {

--- a/pgdog/src/frontend/router/route.rs
+++ b/pgdog/src/frontend/router/route.rs
@@ -107,12 +107,10 @@ impl Route {
 
 impl From<pgdog_plugin::OrderBy> for OrderBy {
     fn from(value: pgdog_plugin::OrderBy) -> Self {
-        if value.column_index < 0 {
+        if let Some(name) = value.name() {
             match value.direction {
-                OrderByDirection_ASCENDING => OrderBy::AscColumn(value.name().unwrap().to_string()),
-                OrderByDirection_DESCENDING => {
-                    OrderBy::DescColumn(value.name().unwrap().to_string())
-                }
+                OrderByDirection_ASCENDING => OrderBy::AscColumn(name.to_string()),
+                OrderByDirection_DESCENDING => OrderBy::DescColumn(name.to_string()),
                 _ => unreachable!("OrderByDirection enum can only be ASCENDING or DESCENDING"),
             }
         } else {

--- a/pgdog/src/frontend/router/route.rs
+++ b/pgdog/src/frontend/router/route.rs
@@ -126,7 +126,7 @@ impl From<pgdog_plugin::OrderBy> for OrderBy {
 impl From<pgdog_plugin::Route> for Route {
     fn from(value: pgdog_plugin::Route) -> Self {
         let all_shards = value.is_all_shards();
-        let shard = value.shard().map(|s| s as usize);
+        let shard = value.shard();
         let affinity = value.affinity;
         let mut order_by = vec![];
 

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -90,43 +90,37 @@ impl DataRow {
 
     /// Get integer at index with text/binary encoding.
     pub fn get_int(&self, index: usize, text: bool) -> Option<i64> {
-        self.column(index)
-            .map(|mut column| {
-                if text {
-                    from_utf8(&column[..])
-                        .ok()
-                        .map(|s| s.parse::<i64>().ok())
-                        .flatten()
-                } else {
-                    match column.len() {
-                        2 => Some(column.get_i16() as i64),
-                        4 => Some(column.get_i32() as i64),
-                        8 => Some(column.get_i64()),
-                        _ => None,
-                    }
+        self.column(index).and_then(|mut column| {
+            if text {
+                from_utf8(&column[..])
+                    .ok()
+                    .and_then(|s| s.parse::<i64>().ok())
+            } else {
+                match column.len() {
+                    2 => Some(column.get_i16() as i64),
+                    4 => Some(column.get_i32() as i64),
+                    8 => Some(column.get_i64()),
+                    _ => None,
                 }
-            })
-            .flatten()
+            }
+        })
     }
 
     // Get integer at index with text/binary encoding.
     pub fn get_float(&self, index: usize, text: bool) -> Option<f64> {
-        self.column(index)
-            .map(|mut column| {
-                if text {
-                    from_utf8(&column[..])
-                        .ok()
-                        .map(|s| s.parse::<f64>().ok())
-                        .flatten()
-                } else {
-                    match column.len() {
-                        4 => Some(column.get_f32() as f64),
-                        8 => Some(column.get_f64()),
-                        _ => None,
-                    }
+        self.column(index).and_then(|mut column| {
+            if text {
+                from_utf8(&column[..])
+                    .ok()
+                    .and_then(|s| s.parse::<f64>().ok())
+            } else {
+                match column.len() {
+                    4 => Some(column.get_f32() as f64),
+                    8 => Some(column.get_f64()),
+                    _ => None,
                 }
-            })
-            .flatten()
+            }
+        })
     }
 }
 

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -136,8 +136,9 @@ impl FromBytes for DataRow {
         let _len = bytes.get_i32();
         let columns = (0..bytes.get_i16())
             .map(|_| {
-                let len = bytes.get_i32() as usize;
+                let len = bytes.get_i32() as isize; // NULL = -1
                 let mut column = BytesMut::new();
+
                 for _ in 0..len {
                     column.put_u8(bytes.get_u8());
                 }

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -1,8 +1,11 @@
 //! DataRow (B) message.
+
 use super::code;
 use super::prelude::*;
 
 use bytes::BytesMut;
+
+use std::str::from_utf8;
 
 /// DataRow message.
 #[derive(Debug, Clone)]
@@ -78,6 +81,52 @@ impl DataRow {
             dr.add(column);
         }
         dr
+    }
+
+    /// Get data for column at index.
+    pub fn column(&self, index: usize) -> Option<Bytes> {
+        self.columns.get(index).cloned()
+    }
+
+    /// Get integer at index with text/binary encoding.
+    pub fn get_int(&self, index: usize, text: bool) -> Option<i64> {
+        self.column(index)
+            .map(|mut column| {
+                if text {
+                    from_utf8(&column[..])
+                        .ok()
+                        .map(|s| s.parse::<i64>().ok())
+                        .flatten()
+                } else {
+                    match column.len() {
+                        2 => Some(column.get_i16() as i64),
+                        4 => Some(column.get_i32() as i64),
+                        8 => Some(column.get_i64()),
+                        _ => None,
+                    }
+                }
+            })
+            .flatten()
+    }
+
+    // Get integer at index with text/binary encoding.
+    pub fn get_float(&self, index: usize, text: bool) -> Option<f64> {
+        self.column(index)
+            .map(|mut column| {
+                if text {
+                    from_utf8(&column[..])
+                        .ok()
+                        .map(|s| s.parse::<f64>().ok())
+                        .flatten()
+                } else {
+                    match column.len() {
+                        4 => Some(column.get_f32() as f64),
+                        8 => Some(column.get_f64()),
+                        _ => None,
+                    }
+                }
+            })
+            .flatten()
     }
 }
 

--- a/pgdog/src/net/messages/row_description.rs
+++ b/pgdog/src/net/messages/row_description.rs
@@ -105,6 +105,17 @@ impl RowDescription {
         self.fields.get(index)
     }
 
+    /// Get field index name, O(n).
+    pub fn field_index(&self, name: &str) -> Option<usize> {
+        for (index, field) in self.fields.iter().enumerate() {
+            if field.name == name {
+                return Some(index);
+            }
+        }
+
+        None
+    }
+
     /// Check if the two row descriptions are materially the same.
     pub fn equivalent(&self, other: &RowDescription) -> bool {
         for (a, b) in self.fields.iter().zip(other.fields.iter()) {

--- a/pgdog/src/net/messages/row_description.rs
+++ b/pgdog/src/net/messages/row_description.rs
@@ -63,6 +63,26 @@ impl Field {
             format: 0, // We always use text format.
         }
     }
+
+    /// Encoded with text encoding.
+    pub fn is_text(&self) -> bool {
+        self.format == 0
+    }
+
+    /// Encoded with binary encoding.
+    pub fn is_binary(&self) -> bool {
+        !self.is_text()
+    }
+
+    /// This is an integer.
+    pub fn is_int(&self) -> bool {
+        matches!(self.type_oid, 20 | 23 | 21)
+    }
+
+    /// This is a float.
+    pub fn is_float(&self) -> bool {
+        matches!(self.type_oid, 700 | 701)
+    }
 }
 
 /// RowDescription message.

--- a/pgdog/src/net/messages/row_description.rs
+++ b/pgdog/src/net/messages/row_description.rs
@@ -100,6 +100,11 @@ impl RowDescription {
         }
     }
 
+    /// Get field info.
+    pub fn field(&self, index: usize) -> Option<&Field> {
+        self.fields.get(index)
+    }
+
     /// Check if the two row descriptions are materially the same.
     pub fn equivalent(&self, other: &RowDescription) -> bool {
         for (a, b) in self.fields.iter().zip(other.fields.iter()) {

--- a/pgdog/tests/psql.sh
+++ b/pgdog/tests/psql.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-PGPASSWORD=pgdog psql -h 127.0.0.1 -p 6432 -U ${1:-pgdog} pgdog
+PGPASSWORD=pgdog psql -h 127.0.0.1 -p 6432 -U ${1:-pgdog} ${2:-pgdog}

--- a/plugins/pgdog-routing/Cargo.toml
+++ b/plugins/pgdog-routing/Cargo.toml
@@ -11,6 +11,8 @@ pgdog-plugin = { path = "../../pgdog-plugin", version = "0.1.1" }
 pg_query = "6.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+rand = "0.8"
+once_cell = "1"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/plugins/pgdog-routing/src/lib.rs
+++ b/plugins/pgdog-routing/src/lib.rs
@@ -134,60 +134,49 @@ fn order_by(stmt: &SelectStmt) -> Result<Vec<OrderBy>, pg_query::Error> {
     let mut order_by = vec![];
     for clause in &stmt.sort_clause {
         if let Some(ref node) = clause.node {
-            match node {
-                NodeEnum::SortBy(sort_by) => {
-                    let asc = match sort_by.sortby_dir {
-                        0 | 1 | 2 => true,
-                        _ => false,
-                    };
-                    if let Some(ref node) = sort_by.node {
-                        if let Some(ref node) = node.node {
-                            match node {
-                                NodeEnum::AConst(aconst) => {
-                                    if let Some(ref val) = aconst.val {
-                                        match val {
-                                            Val::Ival(integer) => {
-                                                order_by.push(OrderBy::column_index(
-                                                    integer.ival as usize,
-                                                    if asc {
-                                                        OrderByDirection_ASCENDING
-                                                    } else {
-                                                        OrderByDirection_DESCENDING
-                                                    },
-                                                ));
-                                            }
-
-                                            _ => (),
-                                        }
+            if let NodeEnum::SortBy(sort_by) = node {
+                let asc = match sort_by.sortby_dir {
+                    0..=2 => true,
+                    _ => false,
+                };
+                if let Some(ref node) = sort_by.node {
+                    if let Some(ref node) = node.node {
+                        match node {
+                            NodeEnum::AConst(aconst) => {
+                                if let Some(ref val) = aconst.val {
+                                    if let Val::Ival(integer) = val {
+                                        order_by.push(OrderBy::column_index(
+                                            integer.ival as usize,
+                                            if asc {
+                                                OrderByDirection_ASCENDING
+                                            } else {
+                                                OrderByDirection_DESCENDING
+                                            },
+                                        ));
                                     }
                                 }
-
-                                NodeEnum::ColumnRef(column_ref) => {
-                                    if let Some(field) = column_ref.fields.first() {
-                                        if let Some(ref node) = field.node {
-                                            match node {
-                                                NodeEnum::String(string) => {
-                                                    order_by.push(OrderBy::column_name(
-                                                        &string.sval,
-                                                        if asc {
-                                                            OrderByDirection_ASCENDING
-                                                        } else {
-                                                            OrderByDirection_DESCENDING
-                                                        },
-                                                    ));
-                                                }
-                                                _ => (),
-                                            }
-                                        }
-                                    }
-                                }
-                                _ => (),
                             }
+
+                            NodeEnum::ColumnRef(column_ref) => {
+                                if let Some(field) = column_ref.fields.first() {
+                                    if let Some(ref node) = field.node {
+                                        if let NodeEnum::String(string) = node {
+                                            order_by.push(OrderBy::column_name(
+                                                &string.sval,
+                                                if asc {
+                                                    OrderByDirection_ASCENDING
+                                                } else {
+                                                    OrderByDirection_DESCENDING
+                                                },
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                            _ => (),
                         }
                     }
                 }
-
-                _ => (),
             }
         }
     }


### PR DESCRIPTION
Add support for `ORDER BY` clause in multi-shard queries. pgDog will sort rows returned from multiple shards automatically.