### PR TITLE
Sharded SELECT queries

### DIFF
--- a/pgdog.toml
+++ b/pgdog.toml
@@ -32,13 +32,6 @@ host = "127.0.0.1"
 database_name = "shard_1"
 shard = 1
 
-#
-# Use pgdog_routing to route things around
-# the cluser.
-#
-[[plugins]]
-name = "pgdog_routing"
-
 
 #
 # Write access to this table will be automatically
@@ -48,3 +41,25 @@ name = "pgdog_routing"
 database = "pgdog_sharded"
 table = "sharded"
 column = "id"
+
+#
+# ActiveRecord sends these queries
+# at startup to figure out the schema.
+#
+# This will route them to only one shard instead of issuing
+# cross-shard queries and getting incorrect results.
+#
+[[manual_queries]]
+fingerprint = "e78fe2c08de5f079" #[16685804461073231993]
+
+[[manual_queries]]
+fingerprint = "43258d068030bb3e" #[4838428433739463486]
+
+[[manual_queries]]
+fingerprint = "08aab2cee482a97d" #[624508100011010429]
+
+[[manual_queries]]
+fingerprint = "23cd60d5972d1712" #[2579824632033777426]
+
+[[manual_queries]]
+fingerprint = "bb38525ebeb46656" #[13490623250668217942]

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use std::fs::read_to_string;
 
 /// pgDog is a PostgreSQL pooler, proxy, load balancer and
 /// query router.
@@ -12,4 +13,50 @@ pub struct Cli {
     /// Path to the users.toml file. Default: "users.toml"
     #[arg(short, long, default_value = "users.toml")]
     pub users: PathBuf,
+    /// Subcommand.
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Run pgDog.
+    Run,
+
+    /// Fingerprint a query.
+    Fingerprint {
+        #[arg(short, long)]
+        query: Option<String>,
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+    },
+}
+
+/// Fingerprint some queries.
+pub fn fingerprint(
+    query: Option<String>,
+    path: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(query) = query {
+        let fingerprint = pg_query::fingerprint(&query)?;
+        println!("{} [{}]", fingerprint.hex, fingerprint.value);
+    } else if let Some(path) = path {
+        let queries = read_to_string(path)?;
+        for query in queries.split(";") {
+            if query.trim().is_empty() {
+                continue;
+            }
+            tracing::debug!("{}", query);
+            if let Ok(fingerprint) = pg_query::fingerprint(query) {
+                println!(
+                    r#"
+[[manual_query]]
+fingerprint = "{}" #[{}]"#,
+                    fingerprint.hex, fingerprint.value
+                );
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -109,6 +109,8 @@ pub struct Config {
     pub admin: Admin,
     #[serde(default)]
     pub sharded_tables: Vec<ShardedTable>,
+    #[serde(default)]
+    pub manual_queries: Vec<ManualQuery>,
 }
 
 impl Config {
@@ -142,6 +144,17 @@ impl Config {
         }
 
         tables
+    }
+
+    /// Manual queries.
+    pub fn manual_queries(&self) -> HashMap<String, ManualQuery> {
+        let mut queries = HashMap::new();
+
+        for query in &self.manual_queries {
+            queries.insert(query.fingerprint.clone(), query.clone());
+        }
+
+        queries
     }
 }
 
@@ -420,6 +433,11 @@ impl Admin {
     }
 }
 
+fn admin_password() -> String {
+    let pw = random_string(12);
+    format!("_pgdog_{}", pw)
+}
+
 /// Sharded table.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ShardedTable {
@@ -432,9 +450,10 @@ pub struct ShardedTable {
     pub column: String,
 }
 
-fn admin_password() -> String {
-    let pw = random_string(12);
-    format!("_pgdog_{}", pw)
+/// Queries with manual routing rules.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ManualQuery {
+    pub fingerprint: String,
 }
 
 #[cfg(test)]

--- a/pgdog/src/frontend/router/parser/csv_buffer.rs
+++ b/pgdog/src/frontend/router/parser/csv_buffer.rs
@@ -2,6 +2,7 @@
 
 use std::mem::take;
 
+/// CSV buffer that supports partial records.
 #[derive(Debug, Clone)]
 pub struct CsvBuffer {
     buffer: Vec<u8>,
@@ -18,6 +19,9 @@ impl CsvBuffer {
     }
 
     /// Add data to buffer.
+    ///
+    /// TODO: Handle new lines escaped between double quotes.
+    ///
     pub fn add(&mut self, data: &[u8]) {
         let nl = data.iter().rev().position(|p| *p as char == '\n');
         if let Some(nl) = nl {

--- a/pgdog/src/frontend/router/parser/csv_buffer.rs
+++ b/pgdog/src/frontend/router/parser/csv_buffer.rs
@@ -9,6 +9,12 @@ pub struct CsvBuffer {
     remainder: Vec<u8>,
 }
 
+impl Default for CsvBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CsvBuffer {
     /// New CSV buffer.
     pub fn new() -> Self {

--- a/pgdog/src/frontend/router/parser/mod.rs
+++ b/pgdog/src/frontend/router/parser/mod.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod order_by;
 pub mod query;
 pub mod route;
+pub mod where_clause;
 
 pub use csv_buffer::CsvBuffer;
 pub use error::Error;

--- a/pgdog/src/frontend/router/parser/order_by.rs
+++ b/pgdog/src/frontend/router/parser/order_by.rs
@@ -1,3 +1,5 @@
+//! Sorting columns extracted from the query.
+
 #[derive(Clone, Debug)]
 pub enum OrderBy {
     Asc(usize),

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -163,7 +163,7 @@ impl QueryParser {
         if let Some(where_clause) = WhereClause::new(&stmt.where_clause) {
             // Complexity: O(number of sharded tables * number of columns in the query)
             for table in sharded_tables {
-                let table_name = table.name.as_ref().map(|s| s.as_str());
+                let table_name = table.name.as_deref();
                 let keys = where_clause.keys(table_name, &table.column);
                 for key in keys {
                     match key {

--- a/pgdog/src/frontend/router/parser/where_clause.rs
+++ b/pgdog/src/frontend/router/parser/where_clause.rs
@@ -1,0 +1,116 @@
+//! WHERE clause of a UPDATE/SELECT/DELETE query.
+
+use pg_query::{
+    protobuf::{a_const::Val, *},
+    Error, NodeEnum,
+};
+use std::string::String;
+
+pub struct Column {
+    table: Option<String>,
+    name: String,
+}
+
+pub enum Output {
+    Parameter(usize),
+    Value(String),
+    Int(i32),
+    Column(Column),
+    Filter(Column, Box<Output>),
+}
+
+pub struct WhereClause {}
+
+impl WhereClause {
+    pub fn new(where_clause: &Option<Node>) -> Result<Option<WhereClause>, Error> {
+        let Some(ref where_clause) = where_clause else {
+            return Ok(None);
+        };
+
+        let Some(ref node) = where_clause.node else {
+            return Ok(None);
+        };
+
+        match node {
+            NodeEnum::BoolExpr(ref expr) => {
+                for arg in &expr.args {
+                    let Some(ref node) = arg.node else {
+                        continue;
+                    };
+
+                    match node {
+                        NodeEnum::AExpr(ref aexpr) => {}
+
+                        _ => continue,
+                    }
+                }
+            }
+
+            _ => (),
+        };
+
+        todo!()
+    }
+
+    fn parse(node: &Node) -> Result<Vec<Output>, Error> {
+        let mut keys = vec![];
+
+        match node.node {
+            Some(NodeEnum::BoolExpr(ref expr)) => {
+                for arg in &expr.args {
+                    keys.extend(Self::parse(arg)?);
+                }
+            }
+
+            Some(NodeEnum::AExpr(ref expr)) => {
+                if let Some(ref left) = expr.lexpr {}
+
+                if let Some(ref right) = expr.rexpr {
+                    keys.extend(Self::parse(right)?);
+                }
+            }
+
+            Some(NodeEnum::AConst(ref value)) => {
+                if let Some(ref val) = value.val {
+                    match val {
+                        Val::Ival(int) => keys.push(Output::Int(int.ival)),
+                        Val::Sval(sval) => keys.push(Output::Value(sval.sval.clone())),
+                        _ => (),
+                    }
+                }
+            }
+
+            _ => (),
+        };
+
+        Ok(keys)
+    }
+
+    fn column(node: &Node) -> Result<Option<Column>, Error> {
+        fn string(node: Option<&Node>) -> Option<String> {
+            if let Some(ref node) = node {
+                match node.node {
+                    Some(NodeEnum::String(ref string)) => return Some(string.sval.clone()),
+                    _ => (),
+                }
+            }
+
+            None
+        }
+
+        match node.node {
+            Some(NodeEnum::ColumnRef(ref column)) => {
+                let name = string(column.fields.last());
+                let table = string(column.fields.iter().rev().nth(1));
+
+                if let Some(name) = name {
+                    return Ok(Some(Column { name, table }));
+                }
+            }
+
+            _ => (),
+        }
+
+        Ok(None)
+    }
+}

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -2,12 +2,13 @@
 
 use backend::databases;
 use clap::Parser;
+use cli::Commands;
 use frontend::listener::Listener;
 use tokio::runtime::Builder;
 use tracing::{info, level_filters::LevelFilter};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use std::io::IsTerminal;
+use std::{io::IsTerminal, process::exit};
 
 pub mod admin;
 pub mod auth;
@@ -47,6 +48,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Cli::parse();
 
     logger();
+
+    match args.command {
+        Some(Commands::Fingerprint { query, path }) => {
+            cli::fingerprint(query, path)?;
+            exit(0);
+        }
+
+        None | Some(Commands::Run) => (),
+    }
+
     info!("🐕 pgDog {}", env!("CARGO_PKG_VERSION"));
 
     let config = config::load(&args.config, &args.users)?;

--- a/pgdog/src/net/messages/bind.rs
+++ b/pgdog/src/net/messages/bind.rs
@@ -49,7 +49,7 @@ impl ParameterWithFormat<'_> {
     }
 
     /// Get BIGINT if one is encoded in the field.
-    pub fn bigin(&self) -> Option<i64> {
+    pub fn bigint(&self) -> Option<i64> {
         match self.format {
             Format::Text => self.text().and_then(|data| data.parse().ok()),
             Format::Binary => self

--- a/pgdog/src/net/messages/bind.rs
+++ b/pgdog/src/net/messages/bind.rs
@@ -51,13 +51,13 @@ impl ParameterWithFormat<'_> {
     /// Get BIGINT if one is encoded in the field.
     pub fn bigin(&self) -> Option<i64> {
         match self.format {
-            Format::Text => self.text().map(|data| data.parse().ok()).flatten(),
+            Format::Text => self.text().and_then(|data| data.parse().ok()),
             Format::Binary => self
                 .parameter
                 .data
                 .as_slice()
                 .try_into()
-                .map(|slice| i64::from_be_bytes(slice))
+                .map(i64::from_be_bytes)
                 .ok(),
         }
     }
@@ -65,13 +65,13 @@ impl ParameterWithFormat<'_> {
     /// Get UUID, if one is encoded in the field.
     pub fn uuid(&self) -> Option<Uuid> {
         match self.format {
-            Format::Text => self.text().map(|uuid| Uuid::from_str(uuid).ok()).flatten(),
+            Format::Text => self.text().and_then(|uuid| Uuid::from_str(uuid).ok()),
             Format::Binary => self
                 .parameter
                 .data
                 .as_slice()
                 .try_into()
-                .map(|slice| Uuid::from_bytes(slice))
+                .map(Uuid::from_bytes)
                 .ok(),
         }
     }
@@ -108,7 +108,7 @@ impl Bind {
     }
 
     /// Get parameter at index.
-    pub fn parameter<'a>(&'a self, index: usize) -> Result<Option<ParameterWithFormat<'a>>, Error> {
+    pub fn parameter(&self, index: usize) -> Result<Option<ParameterWithFormat<'_>>, Error> {
         let format = self.parameter_format(index)?;
         Ok(self
             .params

--- a/pgdog/src/net/messages/bind.rs
+++ b/pgdog/src/net/messages/bind.rs
@@ -1,12 +1,15 @@
 //! Bind (F) message.
 use crate::net::c_string_buf;
 use pgdog_plugin::bindings::Parameter as PluginParameter;
+use uuid::Uuid;
 
 use super::code;
 use super::prelude::*;
 use super::Error;
 
 use std::cmp::max;
+use std::str::from_utf8;
+use std::str::FromStr;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum Format {
@@ -30,6 +33,48 @@ pub struct Parameter {
     pub len: i32,
     /// Parameter data.
     pub data: Vec<u8>,
+}
+
+/// Parameter with encoded format.
+#[derive(Debug, Clone)]
+pub struct ParameterWithFormat<'a> {
+    parameter: &'a Parameter,
+    format: Format,
+}
+
+impl ParameterWithFormat<'_> {
+    /// Get text representation if it's valid UTF-8.
+    pub fn text(&self) -> Option<&str> {
+        from_utf8(&self.parameter.data).ok()
+    }
+
+    /// Get BIGINT if one is encoded in the field.
+    pub fn bigin(&self) -> Option<i64> {
+        match self.format {
+            Format::Text => self.text().map(|data| data.parse().ok()).flatten(),
+            Format::Binary => self
+                .parameter
+                .data
+                .as_slice()
+                .try_into()
+                .map(|slice| i64::from_be_bytes(slice))
+                .ok(),
+        }
+    }
+
+    /// Get UUID, if one is encoded in the field.
+    pub fn uuid(&self) -> Option<Uuid> {
+        match self.format {
+            Format::Text => self.text().map(|uuid| Uuid::from_str(uuid).ok()).flatten(),
+            Format::Binary => self
+                .parameter
+                .data
+                .as_slice()
+                .try_into()
+                .map(|slice| Uuid::from_bytes(slice))
+                .ok(),
+        }
+    }
 }
 
 /// Bind (F) message.
@@ -60,6 +105,15 @@ impl Bind {
         } else {
             Ok(Format::Text)
         }
+    }
+
+    /// Get parameter at index.
+    pub fn parameter<'a>(&'a self, index: usize) -> Result<Option<ParameterWithFormat<'a>>, Error> {
+        let format = self.parameter_format(index)?;
+        Ok(self
+            .params
+            .get(index)
+            .map(|parameter| ParameterWithFormat { parameter, format }))
     }
 
     /// Convert bind parameters to plugin parameters.

--- a/pgdog/tests/pypg.py
+++ b/pgdog/tests/pypg.py
@@ -8,9 +8,23 @@ async def test_asyncpg():
 		password='pgdog',
 		database='pgdog',
 		host='127.0.0.1',
-		port=6432)
+		port=6432,
+		statement_cache_size=0)
 	for i in range(100):
 		values = await conn.fetch("SELECT $1::int, $2::text", 1, "1")
 	await conn.close()
 
-asyncio.run(test_asyncpg())
+async def test_sharded():
+    conn = await asyncpg.connect(
+		user='pgdog',
+		password='pgdog',
+		database='pgdog_sharded',
+		host='127.0.0.1',
+		port=6432,
+		statement_cache_size=0)
+    for v in range(1):
+        values = await conn.fetch("SELECT * FROM sharded WHERE id = $1", v)
+    await conn.close()
+
+# asyncio.run(test_asyncpg())
+asyncio.run(test_sharded())

--- a/pgdog/tests/rails_schema_cache.txt
+++ b/pgdog/tests/rails_schema_cache.txt
@@ -1,0 +1,34 @@
+SELECT t.oid, t.typname
+FROM pg_type as t
+WHERE t.typname IN ('int2', 'int4', 'int8', 'oid', 'float4', 'float8', 'numeric', 'bool', 'timestamp', 'timestamptz');
+
+SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
+FROM pg_type as t
+LEFT JOIN pg_range as r ON oid = rngtypid
+WHERE
+  t.typname IN ('int2', 'int4', 'int8', 'oid', 'float4', 'float8', 'text', 'varchar', 'char', 'name', 'bpchar', 'bool', 'bit', 'varbit', 'date', 'money', 'bytea', 'point', 'hstore', 'json', 'jsonb', 'cidr', 'inet', 'uuid', 'xml', 'tsvector', 'macaddr', 'citext', 'ltree', 'line', 'lseg', 'box', 'path', 'polygon', 'circle', 'numeric', 'interval', 'time', 'timestamp', 'timestamptz');
+
+SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
+FROM pg_type as t
+LEFT JOIN pg_range as r ON oid = rngtypid
+WHERE
+  t.typtype IN ('r', 'e', 'd');
+
+SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
+FROM pg_type as t
+LEFT JOIN pg_range as r ON oid = rngtypid
+WHERE
+  t.typelem IN (16, 17, 18, 19, 20, 21, 23, 25, 26, 114, 142, 600, 601, 602, 603, 604, 628, 700, 701, 718, 790, 829, 869, 650, 1042, 1043, 1082, 1083, 1114, 1184, 1186, 1560, 1562, 1700, 2950, 3614, 3802, 13279, 13282, 13284, 13290, 13292, 3904, 3906, 3908, 3910, 3912, 3926);
+
+SELECT a.attname, format_type(a.atttypid, a.atttypmod),
+       pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
+       c.collname, col_description(a.attrelid, a.attnum) AS comment,
+       attidentity AS identity,
+       attgenerated as attgenerated
+  FROM pg_attribute a
+  LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+  LEFT JOIN pg_type t ON a.atttypid = t.oid
+  LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
+ WHERE a.attrelid = '"sharded"'::regclass
+   AND a.attnum > 0 AND NOT a.attisdropped
+ ORDER BY a.attnum;

--- a/pgdog/tests/rails_tests.rb
+++ b/pgdog/tests/rails_tests.rb
@@ -1,0 +1,20 @@
+require 'active_record'
+
+ActiveRecord::Base.establish_connection(
+  :adapter => "postgresql",
+  :host => "127.0.0.1",
+  :port => 6432,
+  :database => "pgdog_sharded",
+  :password => "pgdog",
+  :user => "pgdog",
+  :prepared_statements => false,
+)
+
+class Sharded < ActiveRecord::Base
+  self.table_name = "sharded"
+  self.primary_key = "id"
+end
+
+1.times do |i|
+  count = Sharded.where(id: 1).count
+end


### PR DESCRIPTION
Add support for automatically detecting sharding columns in SELECT statements and routing them to the right shards. Supports both simple and extended protocols. Prepared statements are TODO.