### PR TITLE
Schema loading & database-url

### DIFF
--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -39,6 +39,7 @@ csv-core = "0.1"
 pg_query = "6"
 regex = "1"
 uuid = { version = "1", features = ["v4"] }
+url = "2"
 
 [build-dependencies]
 cc = "1"

--- a/pgdog/src/backend/mod.rs
+++ b/pgdog/src/backend/mod.rs
@@ -4,11 +4,13 @@ pub mod databases;
 pub mod error;
 pub mod pool;
 pub mod replication;
+pub mod schema;
 pub mod server;
 pub mod stats;
 
 pub use error::Error;
 pub use pool::{Cluster, Pool, Replicas, Shard};
 pub use replication::ShardedTables;
+pub use schema::Schema;
 pub use server::Server;
 pub use stats::Stats;

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -204,13 +204,15 @@ mod test {
 
     impl Cluster {
         pub fn new_test() -> Self {
-            let mut cluster = Self::default();
-            cluster.sharded_tables = ShardedTables::new(vec![ShardedTable {
-                database: "pgdog".into(),
-                name: Some("sharded".into()),
-                column: "id".into(),
-            }]);
-            cluster.shards = vec![Shard::default(), Shard::default()];
+            let cluster = Cluster {
+                sharded_tables: ShardedTables::new(vec![ShardedTable {
+                    database: "pgdog".into(),
+                    name: Some("sharded".into()),
+                    column: "id".into(),
+                }]),
+                shards: vec![Shard::default(), Shard::default()],
+                ..Default::default()
+            };
 
             cluster
         }

--- a/pgdog/src/backend/pool/mod.rs
+++ b/pgdog/src/backend/pool/mod.rs
@@ -39,4 +39,4 @@ use mapping::Mapping;
 use waiting::Waiting;
 
 #[cfg(test)]
-mod test;
+pub mod test;

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -118,7 +118,9 @@ impl Monitor {
 
                     if idle > 0 {
                         comms.ready.notify_waiters();
-                    } else if should_create {
+                    }
+
+                    if should_create {
                         self.pool.lock().creating();
                         let ok = self.replenish(connect_timeout).await;
                         if ok {

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -15,7 +15,7 @@ use super::*;
 
 mod replica;
 
-fn pool() -> Pool {
+pub fn pool() -> Pool {
     let config = Config {
         max: 1,
         min: 1,

--- a/pgdog/src/backend/schema/mod.rs
+++ b/pgdog/src/backend/schema/mod.rs
@@ -1,0 +1,53 @@
+pub mod queries;
+use std::collections::HashMap;
+
+pub use queries::{Table, TABLES};
+
+use crate::net::messages::{DataRow, FromBytes, Protocol, ToBytes};
+
+use super::{Error, Server};
+
+#[derive(Debug, Clone, Default)]
+pub struct Schema {
+    tables: HashMap<(String, String), Table>,
+}
+
+impl Schema {
+    /// Load schema from a server connection.
+    pub async fn load(server: &mut Server) -> Result<Self, Error> {
+        let result = server.execute(TABLES).await?;
+        let mut tables = HashMap::new();
+
+        for message in result {
+            if message.code() == 'D' {
+                let row = DataRow::from_bytes(message.to_bytes()?)?;
+                let table = Table::from(row);
+                tables.insert((table.schema.clone(), table.name.clone()), table);
+            }
+        }
+
+        Ok(Self { tables })
+    }
+
+    /// Get table by name.
+    pub fn table(&self, name: &str, schema: Option<&str>) -> Option<&Table> {
+        let schema = schema.unwrap_or("public");
+        self.tables.get(&(name.to_string(), schema.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::net::messages::BackendKeyData;
+
+    use super::super::pool::test::pool;
+    use super::Schema;
+
+    #[tokio::test]
+    async fn test_schema() {
+        let pool = pool();
+        let mut conn = pool.get(&BackendKeyData::new()).await.unwrap();
+        let _schema = Schema::load(&mut conn).await.unwrap();
+        // println!("{:#?}", schema);
+    }
+}

--- a/pgdog/src/backend/schema/queries.rs
+++ b/pgdog/src/backend/schema/queries.rs
@@ -1,0 +1,31 @@
+use crate::net::messages::DataRow;
+
+/// Get all tables in the database.
+pub static TABLES: &str = include_str!("tables.sql");
+
+#[derive(Debug, Clone)]
+pub struct Table {
+    pub schema: String,
+    pub name: String,
+    pub type_: String,
+    pub owner: String,
+    pub persistence: String,
+    pub access_method: String,
+    pub size: usize,
+    pub description: String,
+}
+
+impl From<DataRow> for Table {
+    fn from(value: DataRow) -> Self {
+        Self {
+            schema: value.get_text(0).unwrap_or_default(),
+            name: value.get_text(1).unwrap_or_default(),
+            type_: value.get_text(2).unwrap_or_default(),
+            owner: value.get_text(3).unwrap_or_default(),
+            persistence: value.get_text(4).unwrap_or_default(),
+            access_method: value.get_text(5).unwrap_or_default(),
+            size: value.get_int(6, true).unwrap_or_default() as usize,
+            description: value.get_text(7).unwrap_or_default(),
+        }
+    }
+}

--- a/pgdog/src/backend/schema/tables.sql
+++ b/pgdog/src/backend/schema/tables.sql
@@ -1,0 +1,35 @@
+ SELECT n.nspname                                                 AS "schema",
+       c.relname                                                  AS "name",
+       CASE c.relkind
+         WHEN 'r' THEN 'table'
+         WHEN 'v' THEN 'view'
+         WHEN 'm' THEN 'materialized view'
+         WHEN 'i' THEN 'index'
+         WHEN 'S' THEN 'sequence'
+         WHEN 't' THEN 'TOAST table'
+         WHEN 'f' THEN 'foreign table'
+         WHEN 'p' THEN 'partitioned table'
+         WHEN 'I' THEN 'partitioned index'
+       end                                                        AS "type",
+       pg_catalog.pg_get_userbyid(c.relowner)                     AS "owner",
+       CASE c.relpersistence
+         WHEN 'p' THEN 'permanent'
+         WHEN 't' THEN 'temporary'
+         WHEN 'u' THEN 'unlogged'
+       end                                                        AS "persistence",
+       am.amname                                                  AS "access_method",
+       pg_catalog.pg_table_size(c.oid)                            AS "size",
+       pg_catalog.obj_description(c.oid, 'pg_class')              AS "description"
+FROM   pg_catalog.pg_class c
+       LEFT JOIN pg_catalog.pg_namespace n
+              ON n.oid = c.relnamespace
+       LEFT JOIN pg_catalog.pg_am am
+              ON am.oid = c.relam
+WHERE  c.relkind IN ( 'r', 'p', 'v', 'm',
+                      'S', 'f', '' )
+       AND n.nspname <> 'pg_catalog'
+       AND n.nspname !~ '^pg_toast'
+       AND n.nspname <> 'information_schema'
+       -- AND pg_catalog.pg_table_is_visible(c.oid)
+ORDER  BY 1,
+          2;

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -24,7 +24,19 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Run pgDog.
-    Run,
+    Run {
+        /// Size of the connection pool.
+        #[arg(short, long)]
+        pool_size: Option<usize>,
+
+        /// Minimum number of idle connectios to maintain open.
+        #[arg(short, long)]
+        min_pool_size: Option<usize>,
+
+        /// Run the pooler in session mode.
+        #[arg(short, long)]
+        session_mode: Option<bool>,
+    },
 
     /// Fingerprint a query.
     Fingerprint {

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -13,6 +13,9 @@ pub struct Cli {
     /// Path to the users.toml file. Default: "users.toml"
     #[arg(short, long, default_value = "users.toml")]
     pub users: PathBuf,
+    /// Connection URL.
+    #[arg(short, long)]
+    pub database_url: Option<Vec<String>>,
     /// Subcommand.
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -30,6 +33,8 @@ pub enum Commands {
         #[arg(short, long)]
         path: Option<PathBuf>,
     },
+
+    Schema,
 }
 
 /// Fingerprint some queries.

--- a/pgdog/src/config/error.rs
+++ b/pgdog/src/config/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
 
     #[error("{0}, line {1}")]
     MissingField(String, usize),
+
+    #[error("{0}")]
+    Url(#[from] url::ParseError),
 }
 
 impl Error {

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -1,6 +1,7 @@
 //! Configuration.
 
 pub mod error;
+pub mod url;
 
 use error::Error;
 
@@ -28,6 +29,13 @@ pub fn config() -> Arc<ConfigAndUsers> {
 /// Load the configuration file from disk.
 pub fn load(config: &PathBuf, users: &PathBuf) -> Result<ConfigAndUsers, Error> {
     let config = ConfigAndUsers::load(config, users)?;
+    CONFIG.store(Arc::new(config.clone()));
+    Ok(config)
+}
+
+/// Load configuration from a list of database URLs.
+pub fn from_urls(urls: &[String]) -> Result<ConfigAndUsers, Error> {
+    let config = ConfigAndUsers::from_urls(urls)?;
     CONFIG.store(Arc::new(config.clone()));
     Ok(config)
 }
@@ -158,7 +166,7 @@ impl Config {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct General {
     /// Run on this address.
     #[serde(default = "General::host")]
@@ -203,6 +211,28 @@ pub struct General {
     /// Shutdown timeout.
     #[serde(default = "General::default_shutdown_timeout")]
     pub shutdown_timeout: u64,
+}
+
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            host: Self::host(),
+            port: Self::port(),
+            workers: Self::workers(),
+            default_pool_size: Self::default_pool_size(),
+            min_pool_size: Self::min_pool_size(),
+            pooler_mode: PoolerMode::default(),
+            healthcheck_interval: Self::healthcheck_interval(),
+            idle_healthcheck_interval: Self::idle_healthcheck_interval(),
+            idle_healthcheck_delay: Self::idle_healthcheck_delay(),
+            ban_timeout: Self::ban_timeout(),
+            rollback_timeout: Self::rollback_timeout(),
+            load_balancing_strategy: Self::load_balancing_strategy(),
+            tls_certificate: None,
+            tls_private_key: None,
+            shutdown_timeout: Self::default_shutdown_timeout(),
+        }
+    }
 }
 
 impl General {
@@ -274,7 +304,7 @@ impl General {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Stats {}
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Copy, Eq, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum PoolerMode {
     #[default]
@@ -292,7 +322,7 @@ pub enum LoadBalancingStrategy {
 }
 
 /// Database server proxied by pgDog.
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Ord, PartialOrd, Eq)]
 pub struct Database {
     /// Database name visible to the clients.
     pub name: String,
@@ -329,7 +359,7 @@ impl Database {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Ord, PartialOrd, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Role {
     #[default]
@@ -367,7 +397,7 @@ impl Users {
 }
 
 /// User allowed to connect to pgDog.
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, Ord, PartialOrd)]
 pub struct User {
     /// User name.
     pub name: String,

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -1,9 +1,11 @@
 //! Configuration.
 
 pub mod error;
+pub mod overrides;
 pub mod url;
 
 use error::Error;
+pub use overrides::Overrides;
 
 use std::fs::read_to_string;
 use std::sync::Arc;
@@ -38,6 +40,30 @@ pub fn from_urls(urls: &[String]) -> Result<ConfigAndUsers, Error> {
     let config = ConfigAndUsers::from_urls(urls)?;
     CONFIG.store(Arc::new(config.clone()));
     Ok(config)
+}
+
+/// Override some settings.
+pub fn overrides(overrides: Overrides) {
+    let mut config = (*config()).clone();
+    let Overrides {
+        default_pool_size,
+        min_pool_size,
+        session_mode,
+    } = overrides;
+
+    if let Some(default_pool_size) = default_pool_size {
+        config.config.general.default_pool_size = default_pool_size;
+    }
+
+    if let Some(min_pool_size) = min_pool_size {
+        config.config.general.min_pool_size = min_pool_size;
+    }
+
+    if let Some(true) = session_mode {
+        config.config.general.pooler_mode = PoolerMode::Session;
+    }
+
+    CONFIG.store(Arc::new(config));
 }
 
 /// pgdog.toml and users.toml.

--- a/pgdog/src/config/overrides.rs
+++ b/pgdog/src/config/overrides.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone, Default)]
+pub struct Overrides {
+    pub default_pool_size: Option<usize>,
+    pub min_pool_size: Option<usize>,
+    pub session_mode: Option<bool>,
+}

--- a/pgdog/src/config/url.rs
+++ b/pgdog/src/config/url.rs
@@ -53,8 +53,8 @@ impl ConfigAndUsers {
     /// Load from database URLs.
     pub fn from_urls(urls: &[String]) -> Result<Self, Error> {
         let urls = urls
-            .into_iter()
-            .map(|url| Url::parse(&url))
+            .iter()
+            .map(|url| Url::parse(url))
             .collect::<Result<Vec<Url>, url::ParseError>>()?;
         let databases = urls
             .iter()

--- a/pgdog/src/config/url.rs
+++ b/pgdog/src/config/url.rs
@@ -1,0 +1,92 @@
+//! Parse URL and convert to config struct.
+use std::{collections::BTreeSet, env::var};
+use url::Url;
+
+use super::{Config, ConfigAndUsers, Database, Error, User, Users};
+
+fn database_name(url: &Url) -> String {
+    let database = url.path().chars().skip(1).collect::<String>();
+    if database.is_empty() {
+        "postgres".into()
+    } else {
+        database
+    }
+}
+
+impl From<&Url> for Database {
+    fn from(value: &Url) -> Self {
+        let host = value
+            .host()
+            .map(|host| host.to_string())
+            .unwrap_or("127.0.0.1".into());
+        let port = value.port().unwrap_or(5432);
+
+        Database {
+            name: database_name(value),
+            host,
+            port,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<&Url> for User {
+    fn from(value: &Url) -> Self {
+        let user = value.username();
+        let user = if user.is_empty() {
+            var("USER").unwrap_or("postgres".into())
+        } else {
+            user.to_string()
+        };
+        let password = value.password().unwrap_or("postgres").to_owned();
+
+        User {
+            name: user,
+            password,
+            database: database_name(value),
+            ..Default::default()
+        }
+    }
+}
+
+impl ConfigAndUsers {
+    /// Load from database URLs.
+    pub fn from_urls(urls: &[String]) -> Result<Self, Error> {
+        let urls = urls
+            .into_iter()
+            .map(|url| Url::parse(&url))
+            .collect::<Result<Vec<Url>, url::ParseError>>()?;
+        let databases = urls
+            .iter()
+            .map(Database::from)
+            .collect::<BTreeSet<_>>() // Make sure we only have unique entries.
+            .into_iter()
+            .collect::<Vec<_>>();
+        let users = urls
+            .iter()
+            .map(User::from)
+            .collect::<BTreeSet<_>>() // Make sure we only have unique entries.
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        Ok(Self {
+            users: Users { users },
+            config: Config {
+                databases,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_url() {
+        let url = Url::parse("postgres://user:password@host:5432/name").unwrap();
+        println!("{:#?}", url);
+    }
+}

--- a/pgdog/src/frontend/router/parser/csv/iterator.rs
+++ b/pgdog/src/frontend/router/parser/csv/iterator.rs
@@ -10,7 +10,7 @@ impl<'a> Iter<'a> {
     }
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = Result<Record, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/pgdog/src/frontend/router/parser/csv/record.rs
+++ b/pgdog/src/frontend/router/parser/csv/record.rs
@@ -22,11 +22,10 @@ impl std::fmt::Debug for Record {
 
 impl std::fmt::Display for Record {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
+        writeln!(
             f,
-            "{}\n",
+            "{}",
             (0..self.len())
-                .into_iter()
                 .map(|field| self.get(field).unwrap())
                 .collect::<Vec<&str>>()
                 .join(&format!("{}", self.delimiter))
@@ -63,7 +62,6 @@ impl Record {
         self.fields
             .get(index)
             .cloned()
-            .map(|range| from_utf8(&self.data[range]).ok())
-            .flatten()
+            .and_then(|range| from_utf8(&self.data[range]).ok())
     }
 }

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -32,7 +32,7 @@ static REPLICATION_REGEX: Lazy<Regex> = Lazy::new(|| {
 #[derive(Debug, Clone)]
 pub enum Command {
     Query(Route),
-    Copy(CopyParser),
+    Copy(Box<CopyParser>),
     StartTransaction(std::string::String),
     CommitTransaction,
     RollbackTransaction,
@@ -300,7 +300,7 @@ impl QueryParser {
     fn copy(stmt: &CopyStmt, cluster: &Cluster) -> Result<Command, Error> {
         let parser = CopyParser::new(stmt, cluster)?;
         if let Some(parser) = parser {
-            Ok(Command::Copy(parser))
+            Ok(Command::Copy(Box::new(parser)))
         } else {
             Ok(Command::Query(Route::write(None)))
         }

--- a/pgdog/src/frontend/router/parser/value.rs
+++ b/pgdog/src/frontend/router/parser/value.rs
@@ -28,8 +28,7 @@ impl<'a> Value<'a> {
                 .parameter(*placeholder as usize - 1)
                 .ok()
                 .flatten()
-                .map(|value| value.text().map(|value| shard_str(value, shards)))
-                .flatten()
+                .and_then(|value| value.text().map(|value| shard_str(value, shards)))
                 .flatten(),
             _ => self.shard(shards),
         }

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -55,12 +55,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             exit(0);
         }
 
+        Some(Commands::Schema) => (),
+
         None | Some(Commands::Run) => (),
     }
 
     info!("🐕 pgDog {}", env!("CARGO_PKG_VERSION"));
 
-    let config = config::load(&args.config, &args.users)?;
+    let config = if let Some(database_urls) = args.database_url {
+        config::from_urls(&database_urls)?
+    } else {
+        config::load(&args.config, &args.users)?
+    };
 
     plugin::load_from_config()?;
 

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -49,6 +49,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     logger();
 
+    let mut overrides = config::Overrides::default();
+
     match args.command {
         Some(Commands::Fingerprint { query, path }) => {
             cli::fingerprint(query, path)?;
@@ -57,7 +59,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         Some(Commands::Schema) => (),
 
-        None | Some(Commands::Run) => (),
+        Some(Commands::Run {
+            pool_size,
+            min_pool_size,
+            session_mode,
+        }) => {
+            overrides = config::Overrides {
+                min_pool_size,
+                session_mode,
+                default_pool_size: pool_size,
+            };
+        }
+
+        None => (),
     }
 
     info!("🐕 pgDog {}", env!("CARGO_PKG_VERSION"));
@@ -67,6 +81,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         config::load(&args.config, &args.users)?
     };
+
+    config::overrides(overrides);
 
     plugin::load_from_config()?;
 


### PR DESCRIPTION
### Features

- Fetch schema from database. This will be used later for automatic sharding.
- Add `-d / --database-url` launch option to configure database connections from a list of URLs. This avoids having to specify `pgdog.toml` and `users.toml`
- Add optional `--min-pool-size`, `--pool-size` and `--session-mode` to CLI to override values in `pgdog.toml`.
### Bug fix

Fix pool not replenishing connections to maintain `min_pool_size` when idle connections are present.