### PR TITLE
Allow admin connections during shutdown

### DIFF
--- a/pgdog/src/net/discovery/listener.rs
+++ b/pgdog/src/net/discovery/listener.rs
@@ -89,17 +89,13 @@ impl Listener {
                     if let Some(message) = message {
                         debug!("{}: {:#?}", addr, message);
 
-                        match message.payload {
-                            Payload::Stats {
+                        if let Payload::Stats {
                                 clients
-                            } => {
-                                self.inner.lock().peers.insert(addr, State {
-                                    clients,
-                                    last_message: now,
-                                });
-                            }
-
-                            _ => (),
+                            } = message.payload {
+                            self.inner.lock().peers.insert(addr, State {
+                                clients,
+                                last_message: now,
+                            });
                         }
 
                     }

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -54,7 +54,7 @@ impl ErrorResponse {
         ErrorResponse {
             severity: "FATAL".into(),
             code: "57P01".into(),
-            message: "pgDog is shutting down".into(),
+            message: "PgDog is shutting down".into(),
             detail: None,
         }
     }


### PR DESCRIPTION
### Feature

Allow admin connections during shutdown so monitoring tools like DataDog can collect stats while we wait for slow clients to shutdown.

Send graceful error message to regular clients that connect while the pooler is shutting down.